### PR TITLE
Added org credits

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -578,10 +578,6 @@ footer {
   justify-content: space-between;
 }
 
-.greenbeam-footer {
-  font-size: 14px;
-}
-
 .footer-heading h2 {
   padding-bottom: 5px;
   color: var(--primary-text-color);

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -371,7 +371,7 @@ aside h2 {
 
 main {
   display: grid;
-  grid-template-rows: 15% 60% 35%;
+  grid-template-rows: 15% 75% 10%;
   background-color: var(--primary-color);
   height: 100%;
 }
@@ -554,6 +554,17 @@ main {
   background-image: url('../images/lightbeam_icon_about.png');
 }
 
+/* ---------- Credits ---------- */
+.credits {
+  z-index: 3;
+  color: var(--primary-text-color);
+  display: grid;
+  grid-template-columns: fit-content(50%);
+  font-size: 14px;
+  padding-left: 30px;
+  padding-right: 30px;
+}
+
 /* ----------- UI - vis Controls ----------- */
 footer {
   display: grid;
@@ -565,6 +576,10 @@ footer {
   display: flex;
   border-bottom: 1px solid var(--primary-text-color);
   justify-content: space-between;
+}
+
+.greenbeam-footer {
+  font-size: 14px;
 }
 
 .footer-heading h2 {

--- a/src/index.html
+++ b/src/index.html
@@ -126,9 +126,13 @@
         <div id="tooltip"></div>
       </div>
     </section>
+    <div class="credits">
+      <h2>Greenbeam is forked from Firefox Lightbeam and uses the GreenWebFoundation's data.
+        With thanks also to the Prototype Fund and ClimateActionTech!</h2>
+    </div>
     <footer class="unimplemented">
-      <div class="footer-toggle unimplemented">
-        <div class="footer-heading">
+      <div class="footer-toggle">
+        <div class="footer-heading unimplemented">
           <h2>Toggle Controls</h2>
         </div>
         <!-- @todo highlight active controls, add click to toggle controls -->
@@ -164,9 +168,9 @@
       <img class="dialog-icon" src="images/lightbeam_dialog_warningreset.png" alt="">
 
       <div class="dialog-content">
-        <p>Pressing OK will delete all Lightbeam information including connection history, user preferences, block sites
+        <p>Pressing OK will delete all Greenbeam information including connection history, user preferences, block sites
           list, etc.</p>
-        <p>Your browser will be returned to the state of a fresh install of Lightbeam.</p>
+        <p>Your browser will be returned to the state of a fresh install of Greenbeam.</p>
       </div>
 
       <menu class="dialog-options">


### PR DESCRIPTION
Added line to properly credit Lightbeam, GreenWebFoundation and ClimateActionTech! 

Note that this is a pseudo-footer, but is not implemented as such, because Lightbeam has a fairly complex but currently hidden footer. I didn't want to change or delete the bulk of the existing CSS for that footer, but also wanted to be able to control how these credits showed up. 

Design could definitely be fine-tuned. 

<img width="1276" alt="Screen Shot 2019-07-22 at 8 08 00 AM" src="https://user-images.githubusercontent.com/5752139/61610439-75cdd000-ac59-11e9-8719-2c9854047e26.png">
