### PR TITLE
import lightbeam data

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,7 @@
       <h2>Data</h2>
       <div>
         <!-- @todo move this to settings screen -->
-        <button class="import" id="import-data-button">Import data</button>
+        <!-- <button class="import" id="import-data-button">Import data</button> -->
         <button class="download" id="save-data-button">Save Data</button>
         <button class="reset" id="reset-data-button">Reset Data</button>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,8 @@
       </div>
       <h2>Data</h2>
       <div>
-        <!-- @todo add click to save data -->
+        <!-- @todo move this to settings screen -->
+        <button class="import" id="import-data-button">Import data</button>
         <button class="download" id="save-data-button">Save Data</button>
         <button class="reset" id="reset-data-button">Reset Data</button>
       </div>

--- a/src/js/capture.js
+++ b/src/js/capture.js
@@ -234,7 +234,7 @@ async function checkGreenStatus(url) {
 
 // Greenbeam. Here we are filtering out anything that starts with a "badURL."
 function isBadUrl(url) {
-  const badURLS = ['http://127.0.0.1:5500/', 'http://api.thegreenwebfoundation.org/greencheck/', 'moz-extension://'];
+  const badURLS = ['http://127.0.0.1:5500', 'http://api.thegreenwebfoundation.org/greencheck', 'moz-extension://'];
   return badURLS.some(badURL => url.startsWith(badURL));
 }
 

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -264,9 +264,9 @@ const lightbeam = {
     importDataButton.addEventListener('click', async () => {
       console.log("Attempting to import data")
       // prompt for a url to try fetching
-      // let url = prompt("Where should we fetch the data from?")
+      let url = prompt("Where should we fetch the data from?")
 
-      url = "ext-libs/lightbeamData.json"
+      // url = "ext-libs/lightbeamData.json"
       // moz-extension://0f5e2a52-66b8-0940-b06a-3617ed0fce68/
       // sanity check the url
       const fetchedData = await fetch(url)

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -249,6 +249,7 @@ const lightbeam = {
       }
       nodes.push(this.websites[website]);
     }
+    console.log({ nodes, links })
 
     return {
       nodes,
@@ -265,7 +266,7 @@ const lightbeam = {
       // prompt for a url to try fetching
       // let url = prompt("Where should we fetch the data from?")
 
-      url = "moz-extension://0f5e2a52-66b8-0940-b06a-3617ed0fce68/ext-libs/lightbeamData.json"
+      url = "ext-libs/lightbeamData.json"
       // moz-extension://0f5e2a52-66b8-0940-b06a-3617ed0fce68/
       // sanity check the url
       const fetchedData = await fetch(url)
@@ -280,9 +281,10 @@ const lightbeam = {
       console.log(`dbcall`, dbCall)
       // nuke it all and start over
       console.log(`re-rendering`)
+      this.init()
       window.location.reload();
 
-      return dbcall;
+      return dbCall;
 
     })
   },

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -6,6 +6,10 @@ const lightbeam = {
   numGreenSites: 0,
 
   async init() {
+
+
+
+    console.log('initialising the viz')
     this.websites = await storeChild.getAll();
     this.initTPToggle();
     this.renderGraph();
@@ -39,6 +43,7 @@ const lightbeam = {
       trackingProtectionDisabled.hidden = false;
     }
   },
+
 
   renderGraph() {
     const transformedData = this.transformData();
@@ -258,8 +263,10 @@ const lightbeam = {
     importDataButton.addEventListener('click', async () => {
       console.log("Attempting to import data")
       // prompt for a url to try fetching
-      let url = prompt("Where should we fetch the data from?")
+      // let url = prompt("Where should we fetch the data from?")
 
+      url = "moz-extension://0f5e2a52-66b8-0940-b06a-3617ed0fce68/ext-libs/lightbeamData.json"
+      // moz-extension://0f5e2a52-66b8-0940-b06a-3617ed0fce68/
       // sanity check the url
       const fetchedData = await fetch(url)
       console.log({ fetchedData })
@@ -269,7 +276,13 @@ const lightbeam = {
       console.log(`Parsed successfully. ${Object.entries(parsedSites).length} sites to import`)
 
       // delegate work to background thread
-      return await storeChild.importSiteData(parsedSites);
+      const dbCall = await storeChild.importSiteData(parsedSites);
+      console.log(`dbcall`, dbCall)
+      // nuke it all and start over
+      console.log(`re-rendering`)
+      window.location.reload();
+
+      return dbcall;
 
     })
   },

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -51,7 +51,7 @@ const lightbeam = {
   },
 
   addListeners() {
-    this.importData()
+    // this.importData()
     this.downloadData();
     this.resetData();
     storeChild.onUpdate((data) => {

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -46,6 +46,7 @@ const lightbeam = {
   },
 
   addListeners() {
+    this.importData()
     this.downloadData();
     this.resetData();
     storeChild.onUpdate((data) => {
@@ -248,6 +249,29 @@ const lightbeam = {
       nodes,
       links
     };
+  },
+
+  importData() {
+
+    const importDataButton = document.getElementById('import-data-button');
+    console.log(importDataButton)
+    importDataButton.addEventListener('click', async () => {
+      console.log("Attempting to import data")
+      // prompt for a url to try fetching
+      let url = prompt("Where should we fetch the data from?")
+
+      // sanity check the url
+      const fetchedData = await fetch(url)
+      console.log({ fetchedData })
+      // try parsing it
+      const parsedSites = await fetchedData.json()
+      console.log({ parsedSites })
+      console.log(`Parsed successfully. ${Object.entries(parsedSites).length} sites to import`)
+
+      // delegate work to background thread
+      return await storeChild.importSiteData(parsedSites);
+
+    })
   },
 
   downloadData() {

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,10 +1,12 @@
 const store = {
   ALLOWLIST_URL: '/ext-libs/disconnect-entitylist.json',
+  DB_IMPORT: '/ext-libs/lightbeamData.json',
   db: null,
 
   async init() {
     if (!this.db) {
       this.makeNewDatabase();
+      await this.importDatabase()
     }
     browser.runtime.onMessage.addListener((m) => {
       return store.messageHandler(m);
@@ -41,6 +43,23 @@ const store = {
       websites
     });
     this.db.open();
+  },
+
+  async importDatabase(websites) {
+    let dbdump;
+    dbdump = await fetch(this.DB_IMPORT);
+    dbdump = await dbdump.json();
+    console.log(dbdump)
+    for (const site in dbdump) {
+      console.log({ site })
+      let siteInfo = dbdump[site]
+      console.log({ siteInfo })
+      let res = await this._write(siteInfo)
+      console.log({ res })
+    }
+    const siteList = await this.getAll()
+    console.log({ siteList })
+
   },
 
   // get Disconnect Entity List from shavar-prod-lists submodule

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,3 +1,4 @@
+var globalDB
 const store = {
   ALLOWLIST_URL: '/ext-libs/disconnect-entitylist.json',
   DB_IMPORT: '/ext-libs/lightbeamData.json',
@@ -6,6 +7,7 @@ const store = {
   async init() {
     if (!this.db) {
       this.makeNewDatabase();
+      console.log("importing database")
       await this.importDatabase()
     }
     browser.runtime.onMessage.addListener((m) => {
@@ -49,7 +51,9 @@ const store = {
     let dbdump;
     dbdump = await fetch(this.DB_IMPORT);
     dbdump = await dbdump.json();
-    console.log(dbdump)
+    globalDB = this.db
+    console.log({ dbump: dbdump })
+    console.log({ dbdump })
     for (const site in dbdump) {
       console.log({ site })
       let siteInfo = dbdump[site]

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -57,14 +57,17 @@ const store = {
       let res = await this._write(siteInfo)
       counter++
       if (counter % 100 == 0) {
+        console.log(siteInfo)
         console.log(`${counter} out of ${total} sites imported`)
       }
 
     }
     console.log("imported all the sites - woop woop")
     const importedSites = await this.getAll()
-    console.log(importedSites)
-    return importedSites
+    const importedAllSites = await this.getAllForImport()
+    console.log({ importedSites })
+    console.log({ importedAllSites })
+    return importedAllSites
   },
 
   // get Disconnect Entity List from shavar-prod-lists submodule
@@ -170,6 +173,7 @@ const store = {
 
     const publicMethods = [
       'getAll',
+      'getAllForImport',
       'reset',
       'getFirstRequestTime',
       'getNumFirstParties',
@@ -226,7 +230,8 @@ const store = {
       favicon: website.faviconUrl || '',
       firstPartyHostnames: website.firstPartyHostnames || false,
       firstParty: !!website.firstParty,
-      thirdParties: [],
+      isVisible: website.isVisible,
+      thirdParties: website.thirdParties || [],
       //  Eve is of course messing around with the below variable!!
       greenCheck: website.greenCheck
     };
@@ -240,6 +245,15 @@ const store = {
     const websites = await this.db.websites.filter((website) => {
       return website.isVisible || website.firstParty;
     }).toArray();
+    const output = {};
+    for (const website of websites) {
+      output[website.hostname] = this.outputWebsite(website.hostname, website);
+    }
+    return output;
+  },
+
+  async getAllForImport() {
+    const websites = await this.db.websites.toArray();
     const output = {};
     for (const website of websites) {
       output[website.hostname] = this.outputWebsite(website.hostname, website);

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -47,15 +47,24 @@ const store = {
   },
 
   async importDatabase(websites) {
+    console.log({ websites })
+    let counter = 0
+    const total = Object.entries(websites).length
+
     for (const site in websites) {
-      console.log({ site })
-      for (const site in websites) {
-        let siteInfo = websites[site]
-        console.log({ siteInfo })
-        let res = await this._write(siteInfo)
-        console.log({ res })
+      let siteInfo = websites[site]
+      // console.log({ siteInfo })
+      let res = await this._write(siteInfo)
+      counter++
+      if (counter % 100 == 0) {
+        console.log(`${counter} out of ${total} sites imported`)
       }
+
     }
+    console.log("imported all the sites - woop woop")
+    const importedSites = await this.getAll()
+    console.log(importedSites)
+    return importedSites
   },
 
   // get Disconnect Entity List from shavar-prod-lists submodule
@@ -178,21 +187,27 @@ const store = {
     }
   },
 
-  async importSiteData(url) {
+  async importSiteData(websites) {
+    console.log(`received call to import websites`)
+
+    console.log(`resetting db`)
+    const clearedDB = await this.reset()
     // check if the url is there
-    // console.log(`Received url to fetch: ${url}`)
+    // console.log(`Received url to fetch: ${ url }`)
     try {
       // fetch the url
-      const fetchedData = await fetch(url)
-      console.log({ fetchedData })
-      // try parsing it
-      const parsedSites = fetchedData.json()
-      console.log({ parsedSites })
+      // const fetchedData = await fetch(url)
+      // console.log({ fetchedData })
+      // // try parsing it
+      // const parsedSites = fetchedData.json()
+      // console.log({ parsedSites })
 
       // pass the datastructure to the store to import it
-      this.importDatabase(parsedSites)
+      console.log(`importing websites into db`, websites)
+      const importResult = await this.importDatabase(websites)
+      console.log({ importResult })
     } catch (error) {
-      console.log(error)
+      console.log({ error })
     }
 
   },


### PR DESCRIPTION
This PR, designed to address [issue 19][issue 19], and the related performance problems does a few things: 

[issue 19]: https://github.com/eveahe/greenbeam/issues/19

- adds the ability to import previously collected lightbeam datasets, with a new 'import' button
- adds an explicit limit for showing sites, to only show the most recent 100 first party sites, which can be changed
- adds a function, to allow us to export _all_ the sites stored in indexed DB

Combined, the export and import functions allow us to work with realistic datasets to test out new features and UI, without manually needing to click around a set of sites to see how datasets would work.

To decouple adding the performance improvements from the UI changes, I've commented out the import buttons and functions. Uncomment these lines, and make the download data button call `getAllForImport` to export the full dataset instead of the current one